### PR TITLE
Extract training + validation dataset creation into separate kernels

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ It runs on [Jupyter Notebook](https://jupyter-notebook-beginner-guide.readthedoc
 ## Setup
 - Clone this repo and make a root-level directory called `data` that includes the folllowing files:
   - [`commodities.json`](#datacommoditiesjson)
-  - [`ft-commodities-articles.txt`](#dataft-commodities-articlestxt)
-  - [`ft-commodities-articles-test.txt`](#dataft-commodities-articles-testtxt)
+  - [`ft-articles-training.txt`](#dataft-articles-trainingtxt)
+  - [`ft-articles-validation.txt`](#dataft-articles-validationtxt)
+  - [`ft-articles-test.txt`](#dataft-articles-testtxt)
 - Install the Jupyter Notebook App by downloading [Anaconda Distribution](https://www.anaconda.com/products/distribution), which is a common scientific python distribution (and which also includes scientific python packages)
 - Run (from the root-level of this repo): `$ jupyter notebook` - this wil open the notebook on [http://localhost:8888/tree](http://localhost:8888/tree)
 
@@ -17,16 +18,21 @@ It runs on [Jupyter Notebook](https://jupyter-notebook-beginner-guide.readthedoc
 ## Creating entities per article dataset
 - Click the `create-entities-per-article-data.ipynb` file to open this kernel on [http://localhost:8888/notebooks/create-entities-per-article-data.ipynb](http://localhost:8888/notebooks/create-entities-per-article-data.ipynb)
 - Run each of the cells in order from top to bottom, which will create the following files in the `data` directory:
-  - `commodities_entities_per_article_data.json`: commodities identified in each article (non-essential for training the NER model)
+  - `entities_per_article_data.json`: commodities identified in each article (non-essential for training the NER model)
 
 
-## Creating training and validation datasets
-- Click the `create-training-validation-data.ipynb` file to open this kernel on [http://localhost:8888/notebooks/create-training-validation-data.ipynb](http://localhost:8888/notebooks/create-training-validation-data.ipynb)
+## Creating training datasets
+- Click the `create-training-data.ipynb` file to open this kernel on [http://localhost:8888/notebooks/create-training-data.ipynb](http://localhost:8888/notebooks/create-training-data.ipynb)
 - Run each of the cells in order from top to bottom, which will create the following files in the `data` directory:
-  - `commodities_training_data.json` (used by spaCy v2)
-  - `commodities_training_data.spacy` (used by spaCy v3)
-  - `commodities_validation_data.json` (used by spaCy v2)
-  - `commodities_validation_data.spacy` (used by spaCy v3)
+  - `training_data.json` (used by spaCy v2)
+  - `training_data.spacy` (used by spaCy v3)
+
+
+## Creating validation datasets
+- Click the `create-validation-data.ipynb` file to open this kernel on [http://localhost:8888/notebooks/create-validation-data.ipynb](http://localhost:8888/notebooks/create-validation-data.ipynb)
+- Run each of the cells in order from top to bottom, which will create the following files in the `data` directory:
+  - `validation_data.json` (used by spaCy v2)
+  - `validation_data.spacy` (used by spaCy v3)
 
 
 ## Creating a spaCy NER model
@@ -36,8 +42,8 @@ It runs on [Jupyter Notebook](https://jupyter-notebook-beginner-guide.readthedoc
   - **Hardware:** CPU
   - **Optimize for:** efficiency
 - Paste the contents into a root-level file called `base_config.cfg` and update the `[paths]` variables to point to the corresponding spaCy format datasets:
-  - `train = null` -> `train = "/data/commodities_training_data.spacy"`
-  - `dev = null` -> `dev = "/data/commodities_validation_data.spacy"`
+  - `train = null` -> `train = "/data/training_data.spacy"`
+  - `dev = null` -> `dev = "/data/validation_data.spacy"`
 - Run `$ python -m spacy init fill-config base_config.cfg config.cfg` to create from `base_config.cfg` a properly formatted `config.cfg` file that will be used to train the NER model
 - Run `$ python -m spacy train config.cfg --output ./output` to use the training data to create a spaCy NER model, and which will display output that looks like:
 ```
@@ -86,17 +92,17 @@ It will also create an `output` root-level directory which contains `model-best`
 
 
 ## Creating test dataset
-- Click the `commodities-create-test-data.ipynb` file to open this kernel on [http://localhost:8888/notebooks/commodities-create-test-data.ipynb](http://localhost:8888/notebooks/commodities-create-test-data.ipynb)
+- Click the `create-test-data.ipynb` file to open this kernel on [http://localhost:8888/notebooks/create-test-data.ipynb](http://localhost:8888/notebooks/create-test-data.ipynb)
 - Run each of the cells in order from top to bottom, which will create the following file in the `data` directory:
-  - `commodities_test_data.json`: body text segments that have not been used to train/validate the NER model that can be used to test the NER model
+  - `test_data.json`: body text segments that have not been used to train/validate the NER model that can be used to test the NER model
 
 
 ## Conducting an informal NER model test
-- Click the `commodities-test-informal.ipynb` file to open this kernel on [http://localhost:8888/notebooks/commodities-test-informal.ipynb](http://localhost:8888/notebooks/commodities-test-informal.ipynb)
+- Click the `test-informal.ipynb` file to open this kernel on [http://localhost:8888/notebooks/test-informal.ipynb](http://localhost:8888/notebooks/test-informal.ipynb)
 - Run each of the cells in order from top to bottom, which in the final cell will test the specified item from the test data against the NER model
 
 ## Conducting a formal NER model test
-- Click the `commodities-test-formal.ipynb` file to open this kernel on [http://localhost:8888/notebooks/commodities-test-formal.ipynb](http://localhost:8888/notebooks/commodities-test-formal.ipynb)
+- Click the `test-formal.ipynb` file to open this kernel on [http://localhost:8888/notebooks/test-formal.ipynb](http://localhost:8888/notebooks/test-formal.ipynb)
 - Run each of the cells in order from top to bottom, which in the final cell will test all items in the test data against the NER model and display a confusion matrix
 
 
@@ -121,15 +127,11 @@ It will also create an `output` root-level directory which contains `model-best`
 
 ---
 
-#### `data/ft-commodities-articles.txt`
+#### `data/ft-articles-training.txt`
 - Each line should contain an article, starting with its UUID, followed by triple pipes, followed by the body text split into segments delineated by double pipes (I chose to delineate segments based on where line breaks occurred)
 - The file should not end with an empty newline
-- My first attempt used 400 unique articles: 10 articles for each of the 40 commodities (though each article may potentially mention multiple commodities)
+- The file includes **2,000 unique articles**: 100 articles for each of the 20 commodities (though each article may potentially mention multiple commodities)
 - I chose articles that mentioned the commodity in contexts that would clearly define it as such, e.g. "aluminium traders", "US producers of corn-based ethanol", "cobalt and molybdenum futures contracts", etc.
-- I tried to avoid articles that included homonyms of the name of the commodity, e.g.
-  - amber -> Amber Rudd: former British politician
-  - lead -> lead: _the initiative in an action; an example for others to follow_
-  - oats -> Oats/OATS (Order Audit Trail System): system run by the Financial Industry Regulatory Authority
 
 ```
 1e852438-161d-4095-90f8-fccb810b4efe|||Lorem ipsum dolor sit amet…||Ut enim ad minim veniam…||Duis aute irure dolor.
@@ -137,11 +139,21 @@ It will also create an `output` root-level directory which contains `model-best`
 …
 aa1e07d2-0a30-41cd-b146-b730ea5467ad|||At vero eos et accusamus…||Et harum quidem…||Nam libero tempore.
 ```
+
 ---
 
-#### `data/ft-commodities-articles-test.txt`
-- This file follows the same format as used for [`ft-commodities-articles.txt`](#dataft-commodities-articlestxt)
-- My first attempt used 40 unique articles; one article for each of the 40 commodities, plus another 12 articles that include occurrences of the sorts of homonyms mentioned above
+#### `data/ft-articles-validation.txt`
+- This file follows the same format as used for [`ft-articles-training.txt`](#dataft-articles-trainingtxt)
+- The file includes **500 unique articles**: 25 articles for each of the 20 commodities
+
+---
+
+#### `data/ft-articles-test.txt`
+- This file follows the same format as used for [`ft-articles-training.txt`](#dataft-articles-trainingtxt)
+- The file includes **500+ unique articles**: 25 articles for each of the 20 commodities, plus some additional articles with commodities not included in `commodities.json` (to see if the model has learned to identify other commodities), and others with occurrences of homonyms of the name of the commodity to test for false positives, e.g.
+  - cattle -> Cattle's PLC: a British consumer finance company
+  - gold -> Yamana Gold: Canadian gold mine and established producer
+  - rice -> Condoleezza Rice: Former United States Secretary of State
 
 
 ## References

--- a/create-test-data.ipynb
+++ b/create-test-data.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 11,
    "id": "4bcff7ad",
    "metadata": {},
    "outputs": [],
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 12,
    "id": "a9846947",
    "metadata": {},
    "outputs": [],
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 13,
    "id": "93472cf1",
    "metadata": {},
    "outputs": [],
@@ -38,7 +38,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 14,
    "id": "242b2501",
    "metadata": {},
    "outputs": [],
@@ -48,7 +48,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 15,
    "id": "63bf9122",
    "metadata": {},
    "outputs": [],
@@ -66,7 +66,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 16,
    "id": "b7556e64",
    "metadata": {},
    "outputs": [],
@@ -76,7 +76,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 17,
    "id": "1f9c1282",
    "metadata": {
     "scrolled": true
@@ -86,8 +86,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['The aluminium industry has seemed sleepy in comparison with this year’s ructions in the steel sector. No longer. The putative takeover by Rusal, the world’s third largest aluminium producer, of Sual, the sixth largest, will create a global leader, with a $30bn estimated enterprise value.', {'entities': [(4, 13, 'COMMODITY'), (171, 180, 'COMMODITY')]}]\n",
-      "291\n"
+      "['China giveth and China taketh away. That certainly resonates with those taking a punt on aluminium. The metals market is focused on one huge long position built up recently. It is thought to be equivalent to between 50 and 80 per cent of all the aluminium sitting in London Metal Exchange’s warehouses, just over 800,000 tonnes. There is also an unusually large number of March 2007 aluminium calls at strike prices of $3,000 a tonne or more outstanding.', {'entities': [(89, 98, 'COMMODITY'), (246, 255, 'COMMODITY'), (383, 392, 'COMMODITY')]}]\n",
+      "2865\n"
      ]
     }
    ],
@@ -110,12 +110,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 18,
    "id": "af3fbdfc",
    "metadata": {},
    "outputs": [],
    "source": [
-    "write_data(\"data/commodities_test_data.json\", TEST_DATA)"
+    "write_data(\"data/test_data.json\", TEST_DATA)"
    ]
   }
  ],

--- a/create-training-data.ipynb
+++ b/create-training-data.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 18,
    "id": "28498fd5",
    "metadata": {},
    "outputs": [],
@@ -19,7 +19,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 19,
    "id": "5700628d",
    "metadata": {},
    "outputs": [],
@@ -32,7 +32,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 20,
    "id": "76985871",
    "metadata": {},
    "outputs": [],
@@ -44,7 +44,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 21,
    "id": "d4a9c3b8",
    "metadata": {},
    "outputs": [
@@ -63,7 +63,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 22,
    "id": "d6d05b57",
    "metadata": {},
    "outputs": [],
@@ -82,7 +82,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 23,
    "id": "bd60faee",
    "metadata": {},
    "outputs": [],
@@ -96,7 +96,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 24,
    "id": "2eef1b7d",
    "metadata": {},
    "outputs": [
@@ -115,7 +115,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 25,
    "id": "27d214f1",
    "metadata": {},
    "outputs": [],
@@ -125,7 +125,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 26,
    "id": "f7dfc2b1",
    "metadata": {},
    "outputs": [],
@@ -135,7 +135,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 27,
    "id": "eb2b72b5",
    "metadata": {},
    "outputs": [],
@@ -153,18 +153,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 28,
    "id": "dec6180b",
    "metadata": {},
    "outputs": [],
    "source": [
-    "TRAINING_DATA = []\n",
-    "VALIDATION_DATA = []"
+    "TRAINING_DATA = []"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 29,
    "id": "4d0598db",
    "metadata": {},
    "outputs": [
@@ -173,14 +172,12 @@
      "output_type": "stream",
      "text": [
       "['China giveth and China taketh away. That certainly resonates with those taking a punt on aluminium. The metals market is focused on one huge long position built up recently. It is thought to be equivalent to between 50 and 80 per cent of all the aluminium sitting in London Metal Exchange’s warehouses, just over 800,000 tonnes. There is also an unusually large number of March 2007 aluminium calls at strike prices of $3,000 a tonne or more outstanding.', {'entities': [(89, 98, 'COMMODITY'), (246, 255, 'COMMODITY'), (383, 392, 'COMMODITY')]}]\n",
-      "1433\n",
-      "['Yet in spite of several runs up towards $3,000, spot aluminium has not breached that level and now sits at less than $2,800. The squeeze means even high-cost producers can keep their smelters running, and metal has been flooding into LME warehouses, with inventories rising by almost 70,000 tonnes in the past month alone. Producer stocks, held outside the LME, have also seen a big increase across the world.', {'entities': [(53, 62, 'COMMODITY')]}]\n",
-      "1432\n"
+      "2865\n"
      ]
     }
    ],
    "source": [
-    "with open(\"data/ft-commodities-articles.txt\") as f:\n",
+    "with open(\"data/ft-articles-training.txt\") as f:\n",
     "    text = f.read()\n",
     "    articles = text.split(\"\\n\")\n",
     "    for article in articles:\n",
@@ -190,32 +187,25 @@
     "        for segment in segments:\n",
     "            results = test_model(nlp, segment)\n",
     "            if results != None:\n",
-    "                if len(TRAINING_DATA) > len(VALIDATION_DATA):\n",
-    "                    VALIDATION_DATA.append(results)\n",
-    "                else:\n",
-    "                    TRAINING_DATA.append(results)\n",
+    "                TRAINING_DATA.append(results)\n",
     "                \n",
     "print(TRAINING_DATA[0])\n",
-    "print(len(TRAINING_DATA))\n",
-    "\n",
-    "print(VALIDATION_DATA[0])\n",
-    "print(len(VALIDATION_DATA))"
+    "print(len(TRAINING_DATA))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 30,
    "id": "5b152cd2",
    "metadata": {},
    "outputs": [],
    "source": [
-    "write_data(\"data/commodities_training_data.json\", TRAINING_DATA)\n",
-    "write_data(\"data/commodities_validation_data.json\", VALIDATION_DATA)"
+    "write_data(\"data/training_data.json\", TRAINING_DATA)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 31,
    "id": "db5704fe",
    "metadata": {},
    "outputs": [],
@@ -225,25 +215,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 32,
    "id": "f2f87b6d",
    "metadata": {},
    "outputs": [],
    "source": [
-    "commodities_training_data = load_data(\"data/commodities_training_data.json\")\n",
-    "commodities_validation_data = load_data(\"data/commodities_validation_data.json\")"
+    "training_data = load_data(\"data/training_data.json\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 33,
    "id": "05170072",
    "metadata": {},
    "outputs": [],
    "source": [
-    "def create_spacy_format_data(TRAINING_DATA):\n",
+    "def create_spacy_format_data(DATA):\n",
     "    docBin = DocBin() # create a DocBin object\n",
-    "    for text, annotation in tqdm(TRAINING_DATA): # data in previous format\n",
+    "    for text, annotation in tqdm(DATA): # data in previous format\n",
     "        doc = nlp.make_doc(text) # create doc object from text\n",
     "        ents = []\n",
     "        for start, end, label in annotation[\"entities\"]: # add character indexes\n",
@@ -259,7 +248,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 34,
    "id": "e4c58fbb",
    "metadata": {},
    "outputs": [
@@ -267,34 +256,13 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|████████████████████████████████████████████████████████████████████████████████| 1433/1433 [00:00<00:00, 2850.10it/s]\n"
+      "100%|███████████████████████████████████████████████████████████████████████████████████████████████| 2865/2865 [00:00<00:00, 3520.40it/s]\n"
      ]
     }
    ],
    "source": [
-    "commodities_training_data = create_spacy_format_data(commodities_training_data)\n",
-    "commodities_training_data.to_disk(\"data/commodities_training_data.spacy\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "id": "1e73a2d2",
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|████████████████████████████████████████████████████████████████████████████████| 1432/1432 [00:00<00:00, 3666.48it/s]\n"
-     ]
-    }
-   ],
-   "source": [
-    "commodities_validation_data = create_spacy_format_data(commodities_validation_data)\n",
-    "commodities_validation_data.to_disk(\"data/commodities_validation_data.spacy\")"
+    "training_data = create_spacy_format_data(training_data)\n",
+    "training_data.to_disk(\"data/training_data.spacy\")"
    ]
   }
  ],

--- a/create-validation-data.ipynb
+++ b/create-validation-data.ipynb
@@ -2,19 +2,25 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "id": "5216d692",
+   "execution_count": 21,
+   "id": "00fe0164",
    "metadata": {},
    "outputs": [],
    "source": [
     "import json\n",
-    "import spacy"
+    "import random\n",
+    "import spacy\n",
+    "from spacy.language import Language\n",
+    "from spacy.lang.en import English\n",
+    "from spacy.pipeline import EntityRuler\n",
+    "from spacy.tokens import DocBin\n",
+    "from tqdm import tqdm"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "65c168b0",
+   "execution_count": 22,
+   "id": "4d6285a6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -26,8 +32,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "6a823d95",
+   "execution_count": 23,
+   "id": "87613231",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -38,12 +44,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "0b9fa67a",
+   "execution_count": 24,
+   "id": "da700472",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['aluminium', 'Aluminium', 'amber', 'Amber', 'Brent crude', 'cattle', 'Cattle', 'cobalt', 'Cobalt', 'cocoa', 'Cocoa', 'coffee', 'Coffee', 'copper', 'Copper', 'corn', 'Corn', 'cotton', 'Cotton', 'crude oil', 'Crude oil', 'ethanol', 'Ethanol', 'gold', 'Gold', 'grain', 'Grain', 'heating oil', 'Heating oil', 'hogs', 'Hogs', 'iron', 'Iron', 'lead', 'Lead', 'lithium', 'Lithium', 'milk', 'Milk', 'molybdenum', 'Molybdenum', 'natural gas', 'Natural gas', 'nickel', 'Nickel', 'oats', 'Oats', 'palladium', 'Palladium', 'palm oil', 'Palm oil', 'platinum', 'Platinum', 'poultry', 'Poultry', 'propane', 'Propane', 'rapeseed', 'Rapeseed', 'rice', 'Rice', 'rubber', 'Rubber', 'silver', 'Silver', 'soybeans', 'Soybeans', 'soya beans', 'Soya beans', 'sugar', 'Sugar', 'tin', 'Tin', 'wheat', 'Wheat', 'wool', 'Wool', 'zinc', 'Zinc']\n"
+     ]
+    }
+   ],
+   "source": [
+    "commodities = load_data(\"data/commodities.json\")\n",
+    "print(commodities)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "8a978905",
    "metadata": {},
    "outputs": [],
    "source": [
-    "def create_training_data(file, type):\n",
+    "def create_validation_data(file, type):\n",
     "    data = load_data(file)\n",
     "    patterns = []\n",
     "    for item in data:\n",
@@ -57,8 +84,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "cca280d0",
+   "execution_count": 26,
+   "id": "265cc0cc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -71,8 +98,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "26c1cca9",
+   "execution_count": 27,
+   "id": "503a4f1b",
    "metadata": {
     "scrolled": true
    },
@@ -86,14 +113,24 @@
     }
    ],
    "source": [
-    "patterns = create_training_data(\"data/commodities.json\", \"COMMODITY\")\n",
+    "patterns = create_validation_data(\"data/commodities.json\", \"COMMODITY\")\n",
     "print(patterns)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "66fda8a8",
+   "execution_count": 28,
+   "id": "70a971e4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "generate_rules(patterns)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "346b3001",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -102,28 +139,50 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "daa8757b",
+   "execution_count": 30,
+   "id": "aa4e2251",
    "metadata": {},
    "outputs": [],
    "source": [
     "def test_model(model, text):\n",
     "    doc = nlp(text)\n",
     "    results = []\n",
+    "    entities = []\n",
     "    for ent in doc.ents:\n",
-    "        results.append(ent.text)\n",
-    "    return results"
+    "        entities.append((ent.start_char, ent.end_char, ent.label_))\n",
+    "    if len(entities) > 0:\n",
+    "        results = [text, {\"entities\": entities}]\n",
+    "        return results"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "381cb378",
+   "execution_count": 31,
+   "id": "336dcf70",
    "metadata": {},
    "outputs": [],
    "source": [
-    "ie_data = {}\n",
-    "\n",
+    "VALIDATION_DATA = []"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "63d29aaa",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['China giveth and China taketh away. That certainly resonates with those taking a punt on aluminium. The metals market is focused on one huge long position built up recently. It is thought to be equivalent to between 50 and 80 per cent of all the aluminium sitting in London Metal Exchange’s warehouses, just over 800,000 tonnes. There is also an unusually large number of March 2007 aluminium calls at strike prices of $3,000 a tonne or more outstanding.', {'entities': [(89, 98, 'COMMODITY'), (246, 255, 'COMMODITY'), (383, 392, 'COMMODITY')]}]\n",
+      "2865\n"
+     ]
+    }
+   ],
+   "source": [
     "with open(\"data/ft-commodities-articles.txt\") as f:\n",
     "    text = f.read()\n",
     "    articles = text.split(\"\\n\")\n",
@@ -133,39 +192,83 @@
     "        hits = []\n",
     "        for segment in segments:\n",
     "            results = test_model(nlp, segment)\n",
-    "            for result in results:\n",
-    "                hits.append(result)\n",
-    "        ie_data[articleUuid] = hits"
+    "            if results != None:\n",
+    "                VALIDATION_DATA.append(results)\n",
+    "                \n",
+    "print(VALIDATION_DATA[0])\n",
+    "print(len(VALIDATION_DATA))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "id": "4b309795",
-   "metadata": {
-    "scrolled": true
-   },
+   "execution_count": 33,
+   "id": "f43f100c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "write_data(\"data/validation_data.json\", VALIDATION_DATA)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "6f142fa1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nlp = spacy.blank(\"en\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "69dec3a9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validation_data = load_data(\"data/validation_data.json\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "85ce824d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def create_spacy_format_data(DATA):\n",
+    "    docBin = DocBin() # create a DocBin object\n",
+    "    for text, annotation in tqdm(DATA): # data in previous format\n",
+    "        doc = nlp.make_doc(text) # create doc object from text\n",
+    "        ents = []\n",
+    "        for start, end, label in annotation[\"entities\"]: # add character indexes\n",
+    "            span = doc.char_span(start, end, label=label, alignment_mode=\"contract\")\n",
+    "            if span is None:\n",
+    "                print (\"Skipping entity\")\n",
+    "            else:\n",
+    "                ents.append(span)\n",
+    "        doc.ents = ents # label the text with the ents\n",
+    "        docBin.add(doc)\n",
+    "    return (docBin)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "id": "c6d0f50b",
+   "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
+     "name": "stderr",
      "output_type": "stream",
      "text": [
-      "['ethanol', 'Cotton', 'corn', 'ethanol', 'corn', 'wheat', 'cotton', 'cotton', 'wheat', 'cotton', 'wheat', 'cotton', 'cotton', 'nickel', 'cotton', 'cotton']\n"
+      "100%|███████████████████████████████████████████████████████████████████████████████████████████████| 2865/2865 [00:00<00:00, 3366.21it/s]\n"
      ]
     }
    ],
    "source": [
-    "print(ie_data['c424190e-7e7f-11dc-8fac-0000779fd2ac'])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "id": "87ca0150",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "write_data(\"data/entities_per_article_data.json\", ie_data)"
+    "validation_data = create_spacy_format_data(validation_data)\n",
+    "validation_data.to_disk(\"data/validation_data.spacy\")"
    ]
   }
  ],


### PR DESCRIPTION
This PR creates separate processes to create the training and validation datasets respectively as it became clear that the training dataset needed to be substantially larger than the validation dataset.

Screengrab from the below-referenced blog:
![Screenshot 2022-06-15 at 11 15 55](https://user-images.githubusercontent.com/10484515/173804002-38c4878a-21cf-4e8f-b9d9-7d6ae521a1d9.png)

#### References:
- [Towards Data Science: About Train, Validation and Test Sets in Machine Learning by Tarang Shah](https://towardsdatascience.com/train-validation-and-test-sets-72cb40cba9e7)