### PR TITLE
Add gold noun misinterpreted as an adjective example

### DIFF
--- a/example-en-core-web-sm-with-ner-pipe.ipynb
+++ b/example-en-core-web-sm-with-ner-pipe.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 2,
    "id": "6a831100",
    "metadata": {},
    "outputs": [],
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 10,
    "id": "6b69cdf0",
    "metadata": {
     "scrolled": false
@@ -42,12 +42,12 @@
     "\n",
     "print(nlp.pipe_names)\n",
     "\n",
-    "doc = nlp(\"Gold is great and this is text about gold the commodity and also about Yamana Gold the company, of which Daniel Racine is CEO, and the other companies called Gold Fields, Auminium Mining Corp, and Goldcorp.\")"
+    "doc = nlp(\"Gold is great and this is text about gold the commodity and also about Yamana Gold the company, of which Daniel Racine is CEO, and the other companies called Gold Fields, Auminium Mining Corp, and Goldcorp. It is also about switching out of the gold ETF [exchange traded fund] into gold equities and gold equity funds.\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 11,
    "id": "f2a222f1",
    "metadata": {
     "scrolled": false
@@ -57,7 +57,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Gold is great and this is text about gold the commodity and also about Yamana Gold the company, of which Daniel Racine is CEO, and the other companies called Gold Fields, Auminium Mining Corp, and Goldcorp.\n"
+      "Gold is great and this is text about gold the commodity and also about Yamana Gold the company, of which Daniel Racine is CEO, and the other companies called Gold Fields, Auminium Mining Corp, and Goldcorp. It is also about switching out of the gold ETF [exchange traded fund] into gold equities and gold equity funds.\n"
      ]
     }
    ],
@@ -67,7 +67,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 12,
    "id": "f75356f1",
    "metadata": {},
    "outputs": [
@@ -114,10 +114,33 @@
        " (,, 'PUNCT'),\n",
        " (and, 'CCONJ'),\n",
        " (Goldcorp, 'PROPN'),\n",
+       " (., 'PUNCT'),\n",
+       " (It, 'PRON'),\n",
+       " (is, 'AUX'),\n",
+       " (also, 'ADV'),\n",
+       " (about, 'ADP'),\n",
+       " (switching, 'VERB'),\n",
+       " (out, 'ADP'),\n",
+       " (of, 'ADP'),\n",
+       " (the, 'DET'),\n",
+       " (gold, 'ADJ'),\n",
+       " (ETF, 'NOUN'),\n",
+       " ([, 'PUNCT'),\n",
+       " (exchange, 'NOUN'),\n",
+       " (traded, 'VERB'),\n",
+       " (fund, 'NOUN'),\n",
+       " (], 'PUNCT'),\n",
+       " (into, 'ADP'),\n",
+       " (gold, 'ADJ'),\n",
+       " (equities, 'NOUN'),\n",
+       " (and, 'CCONJ'),\n",
+       " (gold, 'ADJ'),\n",
+       " (equity, 'NOUN'),\n",
+       " (funds, 'NOUN'),\n",
        " (., 'PUNCT')]"
       ]
      },
-     "execution_count": 56,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -128,7 +151,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 13,
    "id": "2b9da200",
    "metadata": {},
    "outputs": [
@@ -136,7 +159,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(Gold, gold, Yamana Gold, Daniel Racine, Gold Fields, Auminium Mining Corp, Goldcorp)\n"
+      "(Gold, gold, Yamana Gold, Daniel Racine, Gold Fields, Auminium Mining Corp, Goldcorp, ETF)\n"
      ]
     }
    ],
@@ -148,7 +171,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 14,
    "id": "3e3a90ee",
    "metadata": {
     "scrolled": false
@@ -164,7 +187,8 @@
       "Daniel Racine 105 118 380 PERSON\n",
       "Gold Fields 158 169 383 ORG\n",
       "Auminium Mining Corp 171 191 383 ORG\n",
-      "Goldcorp 197 205 383 ORG\n"
+      "Goldcorp 197 205 383 ORG\n",
+      "ETF 250 253 383 ORG\n"
      ]
     }
    ],

--- a/example-en-core-web-sm-without-ner-pipe.ipynb
+++ b/example-en-core-web-sm-without-ner-pipe.ipynb
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 2,
    "id": "e01274f8",
    "metadata": {},
    "outputs": [
@@ -37,12 +37,30 @@
     "\n",
     "print(nlp.pipe_names)\n",
     "\n",
-    "doc = nlp(\"Gold is great and this is text about gold the commodity and also about Yamana Gold the company, of which Daniel Racine is CEO, and the other companies called Gold Fields, Auminium Mining Corp, and Goldcorp.\")"
+    "doc = nlp(\"Gold is great and this is text about gold the commodity and also about Yamana Gold the company, of which Daniel Racine is CEO, and the other companies called Gold Fields, Auminium Mining Corp, and Goldcorp. It is also about switching out of the gold ETF [exchange traded fund] into gold equities and gold equity funds.\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 3,
+   "id": "0be9f30e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Gold is great and this is text about gold the commodity and also about Yamana Gold the company, of which Daniel Racine is CEO, and the other companies called Gold Fields, Auminium Mining Corp, and Goldcorp. It is also about switching out of the gold ETF [exchange traded fund] into gold equities and gold equity funds.\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(doc)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
    "id": "82e3012c",
    "metadata": {},
    "outputs": [
@@ -89,10 +107,33 @@
        " (,, 'PUNCT'),\n",
        " (and, 'CCONJ'),\n",
        " (Goldcorp, 'PROPN'),\n",
+       " (., 'PUNCT'),\n",
+       " (It, 'PRON'),\n",
+       " (is, 'AUX'),\n",
+       " (also, 'ADV'),\n",
+       " (about, 'ADP'),\n",
+       " (switching, 'VERB'),\n",
+       " (out, 'ADP'),\n",
+       " (of, 'ADP'),\n",
+       " (the, 'DET'),\n",
+       " (gold, 'ADJ'),\n",
+       " (ETF, 'NOUN'),\n",
+       " ([, 'PUNCT'),\n",
+       " (exchange, 'NOUN'),\n",
+       " (traded, 'VERB'),\n",
+       " (fund, 'NOUN'),\n",
+       " (], 'PUNCT'),\n",
+       " (into, 'ADP'),\n",
+       " (gold, 'ADJ'),\n",
+       " (equities, 'NOUN'),\n",
+       " (and, 'CCONJ'),\n",
+       " (gold, 'ADJ'),\n",
+       " (equity, 'NOUN'),\n",
+       " (funds, 'NOUN'),\n",
        " (., 'PUNCT')]"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -103,7 +144,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 5,
    "id": "2199b194",
    "metadata": {},
    "outputs": [
@@ -116,12 +157,13 @@
     }
    ],
    "source": [
+    "# The results include instances where gold used as a noun is misinterpreted as an adjective, e.g. \"gold equity funds\".\n",
     "print(doc.ents)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 6,
    "id": "934d18b1",
    "metadata": {},
    "outputs": [

--- a/example-english-import.ipynb
+++ b/example-english-import.ipynb
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 2,
    "id": "ef0c1772",
    "metadata": {},
    "outputs": [
@@ -42,12 +42,12 @@
     "\n",
     "print(nlp.pipe_names)\n",
     "\n",
-    "doc = nlp(\"Gold is great and this is text about gold the commodity and also about Yamana Gold the company, of which Daniel Racine is CEO, and the other companies called Gold Fields, Auminium Mining Corp, and Goldcorp.\")"
+    "doc = nlp(\"Gold is great and this is text about gold the commodity and also about Yamana Gold the company, of which Daniel Racine is CEO, and the other companies called Gold Fields, Auminium Mining Corp, and Goldcorp. It is also about switching out of the gold ETF [exchange traded fund] into gold equities and gold equity funds.\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 3,
    "id": "f07c9ef1",
    "metadata": {
     "scrolled": true
@@ -57,7 +57,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Gold is great and this is text about gold the commodity and also about Yamana Gold the company, of which Daniel Racine is CEO, and the other companies called Gold Fields, Auminium Mining Corp, and Goldcorp.\n"
+      "Gold is great and this is text about gold the commodity and also about Yamana Gold the company, of which Daniel Racine is CEO, and the other companies called Gold Fields, Auminium Mining Corp, and Goldcorp. It is also about switching out of the gold ETF [exchange traded fund] into gold equities and gold equity funds.\n"
      ]
     }
    ],
@@ -67,7 +67,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 4,
    "id": "277caa32",
    "metadata": {},
    "outputs": [
@@ -114,10 +114,33 @@
        " (,, ''),\n",
        " (and, ''),\n",
        " (Goldcorp, ''),\n",
+       " (., ''),\n",
+       " (It, ''),\n",
+       " (is, ''),\n",
+       " (also, ''),\n",
+       " (about, ''),\n",
+       " (switching, ''),\n",
+       " (out, ''),\n",
+       " (of, ''),\n",
+       " (the, ''),\n",
+       " (gold, ''),\n",
+       " (ETF, ''),\n",
+       " ([, ''),\n",
+       " (exchange, ''),\n",
+       " (traded, ''),\n",
+       " (fund, ''),\n",
+       " (], ''),\n",
+       " (into, ''),\n",
+       " (gold, ''),\n",
+       " (equities, ''),\n",
+       " (and, ''),\n",
+       " (gold, ''),\n",
+       " (equity, ''),\n",
+       " (funds, ''),\n",
        " (., '')]"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -128,7 +151,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 5,
    "id": "169465a5",
    "metadata": {},
    "outputs": [
@@ -136,7 +159,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(Gold, gold, Gold, Gold)\n"
+      "(Gold, gold, Gold, Gold, gold, gold, gold)\n"
      ]
     }
    ],
@@ -148,7 +171,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 6,
    "id": "8b617664",
    "metadata": {},
    "outputs": [
@@ -159,7 +182,10 @@
       "Gold 0 4 2181413665215533003 COMMODITY\n",
       "gold 37 41 2181413665215533003 COMMODITY\n",
       "Gold 78 82 2181413665215533003 COMMODITY\n",
-      "Gold 158 162 2181413665215533003 COMMODITY\n"
+      "Gold 158 162 2181413665215533003 COMMODITY\n",
+      "gold 245 249 2181413665215533003 COMMODITY\n",
+      "gold 282 286 2181413665215533003 COMMODITY\n",
+      "gold 300 304 2181413665215533003 COMMODITY\n"
      ]
     }
    ],

--- a/example-part-of-speech-tagging.ipynb
+++ b/example-part-of-speech-tagging.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 1,
    "id": "58cf3cd9",
    "metadata": {},
    "outputs": [],
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 2,
    "id": "d8bea4be",
    "metadata": {},
    "outputs": [
@@ -66,10 +66,33 @@
        " (,, 'PUNCT'),\n",
        " (and, 'CCONJ'),\n",
        " (Goldcorp, 'PROPN'),\n",
+       " (., 'PUNCT'),\n",
+       " (It, 'PRON'),\n",
+       " (is, 'AUX'),\n",
+       " (also, 'ADV'),\n",
+       " (about, 'ADP'),\n",
+       " (switching, 'VERB'),\n",
+       " (out, 'ADP'),\n",
+       " (of, 'ADP'),\n",
+       " (the, 'DET'),\n",
+       " (gold, 'ADJ'),\n",
+       " (ETF, 'NOUN'),\n",
+       " ([, 'PUNCT'),\n",
+       " (exchange, 'NOUN'),\n",
+       " (traded, 'VERB'),\n",
+       " (fund, 'NOUN'),\n",
+       " (], 'PUNCT'),\n",
+       " (into, 'ADP'),\n",
+       " (gold, 'ADJ'),\n",
+       " (equities, 'NOUN'),\n",
+       " (and, 'CCONJ'),\n",
+       " (gold, 'ADJ'),\n",
+       " (equity, 'NOUN'),\n",
+       " (funds, 'NOUN'),\n",
        " (., 'PUNCT')]"
       ]
      },
-     "execution_count": 40,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -79,14 +102,14 @@
     "\n",
     "print(nlp.pipe_names)\n",
     "\n",
-    "doc = nlp(\"Gold is great and this is text about gold the commodity and also about Yamana Gold the company, of which Daniel Racine is CEO, and the other companies called Gold Fields, Auminium Mining Corp, and Goldcorp.\")\n",
+    "doc = nlp(\"Gold is great and this is text about gold the commodity and also about Yamana Gold the company, of which Daniel Racine is CEO, and the other companies called Gold Fields, Auminium Mining Corp, and Goldcorp. It is also about switching out of the gold ETF [exchange traded fund] into gold equities and gold equity funds.\")\n",
     "\n",
     "[(i, i.pos_) for i in doc]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 3,
    "id": "3ad200eb",
    "metadata": {},
    "outputs": [
@@ -94,7 +117,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Gold is great and this is text about gold the commodity and also about Yamana Gold the company, of which Daniel Racine is CEO, and the other companies called Gold Fields, Auminium Mining Corp, and Goldcorp.\n"
+      "Gold is great and this is text about gold the commodity and also about Yamana Gold the company, of which Daniel Racine is CEO, and the other companies called Gold Fields, Auminium Mining Corp, and Goldcorp. It is also about switching out of the gold ETF [exchange traded fund] into gold equities and gold equity funds.\n"
      ]
     }
    ],
@@ -104,7 +127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 4,
    "id": "414add9f",
    "metadata": {},
    "outputs": [
@@ -116,7 +139,8 @@
       "Daniel Racine 105 118 380 PERSON\n",
       "Gold Fields 158 169 383 ORG\n",
       "Auminium Mining Corp 171 191 383 ORG\n",
-      "Goldcorp 197 205 383 ORG\n"
+      "Goldcorp 197 205 383 ORG\n",
+      "ETF 250 253 383 ORG\n"
      ]
     }
    ],


### PR DESCRIPTION
When comparing different pipelines on FT gold-focused content, I noticed that there are some mentions of the word 'gold' as a noun that is interpreted by spaCy's part-of-text identifier as an adjective, e.g. in https://www.ft.com/content/d39d2136-e2b3-11e0-897a-00144feabdc0, 'gold' is interpreted as an adjective in these instances (presumably because of its position of immediately preceding a noun where it could technically be perceived as an adjective):

- gold ETF [exchange traded fund]
- gold equities
- gold equity funds

This PR adds the above examples to the example files as a reminder that there might be lacking precision of identifying gold (and other commodities) as a noun because of cases like the above.