### PR TITLE
Add soyabean + soybean to commodities patterns

### DIFF
--- a/commodities-patterns.json
+++ b/commodities-patterns.json
@@ -230,11 +230,17 @@
 		{ "LOWER": "soya", "POS": "NOUN" }
 	],
 	[
+		{ "LOWER": "soyabean", "POS": "NOUN" }
+	],
+	[
 		{ "LOWER": "soyabeans", "POS": "NOUN" }
 	],
 	[
 		{ "LOWER": "soya", "POS": "NOUN" },
 		{ "LOWER": "beans", "POS": "NOUN" }
+	],
+	[
+		{ "LOWER": "soybean", "POS": "NOUN" }
 	],
 	[
 		{ "LOWER": "soybeans", "POS": "NOUN" }


### PR DESCRIPTION
Mentions of soyabeans and soybeans expressed as a singular collective noun (e.g. soyabean crops, soybean crops) appear a fair amount in the articles about corn, so this PR adds them to the commodities patterns so that automatic pre-annotations can be applied.